### PR TITLE
Compatibility fixes

### DIFF
--- a/cmake/dca_compiler_options.cmake
+++ b/cmake/dca_compiler_options.cmake
@@ -18,17 +18,31 @@
 # unset(CMAKE_REQUIRED_FLAGS)
 
 # Warnings
-set(DCA_WARNINGS -Wall -Wextra -Wpedantic -Wno-sign-compare -Wno-dangling-else)
+if(NOT MSVC)
+  set(DCA_WARNINGS -Wall -Wextra -Wpedantic -Wno-sign-compare -Wno-dangling-else)
 
-# Languange standard
-set(DCA_STD_FLAG -std=c++14)
+  # Languange standard
+  set(DCA_STD_FLAG -std=c++14)
+else()
+  add_compile_options(
+    -D_USE_MATH_DEFINES
+    -D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING
+    -D_CRT_SECURE_NO_WARNINGS
+    -D__PRETTY_FUNCTION__=__FUNCTION__
+    -wd4101 -wd4244 -wd4251 -wd4267)
+
+  # Languange standard
+  set(DCA_STD_FLAG -std:c++14)
+endif()
 
 # Set C and CXX flags.
 add_compile_options(${DCA_WARNINGS})
 add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:${DCA_STD_FLAG}>")
 
 # Add support for multithreading with the Pthread library.
-add_compile_options("-pthread")
+if(NOT MSVC)
+  add_compile_options("-pthread")
+endif()
 
 # Set NVCC flags.
 if (DCA_HAVE_CUDA)

--- a/cmake/dca_external_libs.cmake
+++ b/cmake/dca_external_libs.cmake
@@ -20,8 +20,10 @@ list(APPEND DCA_EXTERNAL_LIBS ${LAPACK_LIBRARIES})
 
 ################################################################################
 # HDF5
-# Find HDF5 by looking for a CMake configuration file (hdf5-1.10.x).
-find_package(HDF5 COMPONENTS C CXX NO_MODULE QUIET)
+if(NOT MSVC)
+  # Find HDF5 by looking for a CMake configuration file (hdf5-1.10.x).
+  find_package(HDF5 COMPONENTS C CXX NO_MODULE QUIET)
+endif()
 if (NOT HDF5_FOUND)
   # Fall back to a search for a FindHDF5.cmake file and execute it.
   find_package(HDF5 REQUIRED COMPONENTS C CXX)

--- a/cmake/dca_hwloc.cmake
+++ b/cmake/dca_hwloc.cmake
@@ -1,0 +1,44 @@
+# Copyright (c)      2014 Thomas Heller
+# Copyright (c) 2007-2012 Hartmut Kaiser
+# Copyright (c) 2010-2011 Matt Anderson
+# Copyright (c) 2011      Bryce Lelbach
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_HWLOC QUIET hwloc)
+
+find_path(HWLOC_INCLUDE_DIR hwloc.h
+  HINTS
+    ${HWLOC_ROOT} ENV HWLOC_ROOT
+    ${PC_HWLOC_MINIMAL_INCLUDEDIR}
+    ${PC_HWLOC_MINIMAL_INCLUDE_DIRS}
+    ${PC_HWLOC_INCLUDEDIR}
+    ${PC_HWLOC_INCLUDE_DIRS}
+  PATH_SUFFIXES include)
+
+find_library(HWLOC_LIBRARY NAMES hwloc libhwloc
+  HINTS
+    ${HWLOC_ROOT} ENV HWLOC_ROOT
+    ${PC_HWLOC_MINIMAL_LIBDIR}
+    ${PC_HWLOC_MINIMAL_LIBRARY_DIRS}
+    ${PC_HWLOC_LIBDIR}
+    ${PC_HWLOC_LIBRARY_DIRS}
+  PATH_SUFFIXES lib lib64)
+
+set(HWLOC_LIBRARIES ${HWLOC_LIBRARY})
+set(HWLOC_INCLUDE_DIRS ${HWLOC_INCLUDE_DIR})
+
+find_package_handle_standard_args(Hwloc DEFAULT_MSG
+  HWLOC_LIBRARY HWLOC_INCLUDE_DIR)
+
+get_property(_type CACHE HWLOC_ROOT PROPERTY TYPE)
+if(_type)
+  set_property(CACHE HWLOC_ROOT PROPERTY ADVANCED 1)
+  if("x${_type}" STREQUAL "xUNINITIALIZED")
+    set_property(CACHE HWLOC_ROOT PROPERTY TYPE PATH)
+  endif()
+endif()
+
+mark_as_advanced(HWLOC_ROOT HWLOC_LIBRARY HWLOC_INCLUDE_DIR)

--- a/include/dca/function/function.hpp
+++ b/include/dca/function/function.hpp
@@ -151,7 +151,7 @@ public:
   // Enable only if all arguments are integral to prevent subind_to_linind(int*, int) to resolve to
   // subind_to_linind(int...) rather than subind_to_linind(const int* const, int).
   template <typename... Ts>
-  std::enable_if_t<util::if_all<std::is_integral<Ts>::value...>::value, int> subind_2_linind(
+  std::enable_if_t<dca::util::if_all<std::is_integral<Ts>::value...>::value, int> subind_2_linind(
       const Ts... subindices) const {
     // We need to cast all subindices to the same type for dmn_variadic.
     return dmn(static_cast<int>(subindices)...);

--- a/include/dca/function/set_to_zero.hpp
+++ b/include/dca/function/set_to_zero.hpp
@@ -18,6 +18,7 @@
 #ifndef DCA_FUNCTION_SET_TO_ZERO_HPP
 #define DCA_FUNCTION_SET_TO_ZERO_HPP
 
+#include <ciso646>
 #include <complex>
 #include <type_traits>
 

--- a/include/dca/io/json/json_parser/json_character_mapper.hpp
+++ b/include/dca/io/json/json_parser/json_character_mapper.hpp
@@ -15,6 +15,16 @@
 #include <iostream>
 #include "dca/io/json/json_parser/json_enumerations.hpp"
 
+#if !defined(_MSC_VER)
+using json_istream = std::wistream;
+using json_ifstream = std::wifstream;
+using json_char = wchar_t;
+#else
+using json_istream = std::istream;
+using json_ifstream = std::ifstream;
+using json_char = char;
+#endif
+
 namespace dca {
 namespace io {
 // dca::io::
@@ -25,7 +35,7 @@ public:
 
   static bool is_white_space(JSON_character_class_type& nextClass);
 
-  static wchar_t get_escaped_character(std::wistream& inputStream);
+  static wchar_t get_escaped_character(json_istream& inputStream);
 
 private:
   static JSON_character_class_type ascii_class[128];

--- a/include/dca/io/json/json_parser/json_parser.hpp
+++ b/include/dca/io/json/json_parser/json_parser.hpp
@@ -34,26 +34,26 @@ class JSON_parser : public JSON_character_mapper, public JSON_mode_stack {
 public:
   JSON_parser();
 
-  bool execute(std::wistream& inputStream);
+  bool execute(json_istream& inputStream);
 
   context_type& get_JSON_tree();
 
 private:
-  std::pair<wchar_t, JSON_character_class_type> get_next_character_and_class(std::wistream& inputStream);
+  std::pair<json_char, JSON_character_class_type> get_next_character_and_class(json_istream& inputStream);
 
   void begin_entity(JSON_action_type& action);
   void end_entity(JSON_action_type& action);
 
   void record_entity(JSON_action_type& action);
 
-  void abort_parsing(wchar_t nextChar, JSON_character_class_type nextClass, JSON_state_type state,
+  void abort_parsing(json_char nextChar, JSON_character_class_type nextClass, JSON_state_type state,
                      JSON_action_type action);
 
   void setCommentState();
 
   void unloadBuffer();
 
-  void performAction(wchar_t nextChar, JSON_character_class_type nextClass, JSON_state_type state,
+  void performAction(json_char nextChar, JSON_character_class_type nextClass, JSON_state_type state,
                      JSON_action_type action);
 
 private:
@@ -137,7 +137,7 @@ void JSON_parser<context_type>::unloadBuffer() {
 }
 
 template <typename context_type>
-void JSON_parser<context_type>::performAction(wchar_t nextChar, JSON_character_class_type nextClass,
+void JSON_parser<context_type>::performAction(json_char nextChar, JSON_character_class_type nextClass,
                                               JSON_state_type state, JSON_action_type action) {
   switch (action) {
     case Consume:
@@ -284,7 +284,7 @@ void JSON_parser<context_type>::record_entity(JSON_action_type& action) {
 }
 
 template <typename context_type>
-void JSON_parser<context_type>::abort_parsing(wchar_t nextChar, JSON_character_class_type nextClass,
+void JSON_parser<context_type>::abort_parsing(json_char nextChar, JSON_character_class_type nextClass,
                                               JSON_state_type state, JSON_action_type action) {
   std::cout << "JsonParser::performAction was sent abort from JSON_parser : \n"
             << "  nextChar   = '" << ((char)wctob(nextChar)) << "'\n"
@@ -299,10 +299,10 @@ void JSON_parser<context_type>::abort_parsing(wchar_t nextChar, JSON_character_c
 }
 
 template <typename context_type>
-bool JSON_parser<context_type>::execute(std::wistream& inputStream) {
-  std::pair<wchar_t, JSON_character_class_type> next = get_next_character_and_class(inputStream);
+bool JSON_parser<context_type>::execute(json_istream& inputStream) {
+  std::pair<json_char, JSON_character_class_type> next = get_next_character_and_class(inputStream);
 
-  wchar_t& nextChar(next.first);
+  json_char& nextChar(next.first);
   JSON_character_class_type& nextClass(next.second);
 
   state_and_action_pair pair = JSON_translation_table::get_state_and_action_pair(state, nextClass);
@@ -325,11 +325,11 @@ bool JSON_parser<context_type>::execute(std::wistream& inputStream) {
 }
 
 template <typename context_type>
-std::pair<wchar_t, JSON_character_class_type> JSON_parser<context_type>::get_next_character_and_class(
-    std::wistream& inputStream) {
-  std::pair<wchar_t, JSON_character_class_type> result;
+std::pair<json_char, JSON_character_class_type> JSON_parser<context_type>::get_next_character_and_class(
+    json_istream& inputStream) {
+  std::pair<json_char, JSON_character_class_type> result;
 
-  wchar_t& nextChar = result.first;
+  json_char& nextChar = result.first;
   JSON_character_class_type& nextClass = result.second;
 
   do {

--- a/include/dca/io/json/json_parser/whatever.hpp
+++ b/include/dca/io/json/json_parser/whatever.hpp
@@ -12,6 +12,7 @@
 #ifndef DCA_IO_JSON_JSON_PARSER_WHATEVER_HPP
 #define DCA_IO_JSON_JSON_PARSER_WHATEVER_HPP
 
+#include <ciso646>
 #include <cstdlib>
 #include <cassert>
 #include <map>

--- a/include/dca/linalg/matrix.hpp
+++ b/include/dca/linalg/matrix.hpp
@@ -13,6 +13,7 @@
 #ifndef DCA_LINALG_MATRIX_HPP
 #define DCA_LINALG_MATRIX_HPP
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <sstream>
@@ -322,8 +323,8 @@ void Matrix<ScalarType, device_name>::resize(std::pair<int, int> new_size) {
 
     ValueType* new_data = nullptr;
     new_data = Allocator::allocate(nrElements(new_capacity));
-    const std::pair<int, int> copy_size(std::min(new_size.first, size_.first),
-                                        std::min(new_size.second, size_.second));
+    const std::pair<int, int> copy_size((std::min)(new_size.first, size_.first),
+                                        (std::min)(new_size.second, size_.second));
     util::memoryCopy(new_data, new_capacity.first, data_, leadingDimension(), copy_size);
     Allocator::deallocate(data_);
 

--- a/include/dca/linalg/util/allocators/aligned_allocator.hpp
+++ b/include/dca/linalg/util/allocators/aligned_allocator.hpp
@@ -12,6 +12,10 @@
 #ifndef DCA_LINALG_UTIL_ALLOCATORS_ALIGNED_ALLOCATOR_HPP
 #define DCA_LINALG_UTIL_ALLOCATORS_ALIGNED_ALLOCATOR_HPP
 
+#if defined(_MSC_VER)
+#include <malloc.h>
+#endif
+
 namespace dca {
 namespace linalg {
 namespace util {
@@ -24,15 +28,25 @@ protected:
     if (!n)
       return nullptr;
 
-    T* ptr;
+    T* ptr = nullptr;
+#if !defined(_MSC_VER)
     int err = posix_memalign((void**)&ptr, 128, n * sizeof(T));
     if (err)
       throw(std::bad_alloc());
+#else
+    ptr = (T*)_aligned_malloc(n * sizeof(T), 128);
+    if (ptr == nullptr)
+      throw(std::bad_alloc());
+#endif
     return ptr;
   }
 
   void deallocate(T*& ptr, std::size_t /*n*/ = 0) noexcept {
+#if !defined(_MSC_VER)
     free(ptr);
+#else
+    _aligned_free(ptr);
+#endif
     ptr = nullptr;
   }
 };

--- a/include/dca/math/geometry/tetrahedron_mesh/tetrahedron_mesh.hpp
+++ b/include/dca/math/geometry/tetrahedron_mesh/tetrahedron_mesh.hpp
@@ -14,6 +14,7 @@
 #define DCA_MATH_GEOMETRY_TETRAHEDRON_MESH_TETRAHEDRON_MESH_HPP
 
 #include <cassert>
+#include <ciso646>
 #include <iostream>
 #include <vector>
 

--- a/include/dca/parallel/hpx/hpxthread.hpp
+++ b/include/dca/parallel/hpx/hpxthread.hpp
@@ -18,74 +18,61 @@
 #include <iostream>
 #include <vector>
 
-//#include "dca/parallel/hpx/hpx_thread_pool/thread_pool.hpp"
 #include "hpx/include/async.hpp"
-#include "hpx/include/threads.hpp"
 #include "hpx/include/future.hpp"
-#include "hpx/include/lcos.hpp"
-#include "hpx/include/local_lcos.hpp"
-#include "hpx/lcos/local/mutex.hpp"
-#include "hpx/lcos/local/condition_variable.hpp"
-#include "hpx/lcos/local/packaged_task.hpp"
 
 namespace dca {
-    namespace parallel {
+namespace parallel {
 
-        class hpxthread {
-        public:
-            hpxthread() = default;
+class hpxthread {
+public:
+  hpxthread() = default;
 
-            // Executes the function f(id, num_tasks, args...) for each integer value of id in [0, num_tasks).
-            template <class F, class... Args>
-            void execute(int num_threads, F&& f, Args&&... args) {
-                assert(num_threads > 0);
+  // Executes the function f(id, num_tasks, args...) for each integer value of id in [0, num_tasks).
+  template <class F, class... Args>
+  void execute(int num_threads, F&& f, Args&&... args) {
+    assert(num_threads > 0);
 
-                std::vector<hpx::future<void>> futures;
-//                auto& pool = HPXThreadPool::get_instance();
-//                pool.enlarge(num_threads);
+    std::vector<hpx::future<void>> futures;
 
-                // Fork.
-                for (int id = 0; id < num_threads; ++id)
-                    futures.emplace_back(
-                            hpx::async(std::forward<F>(f), id, num_threads, std::forward<Args>(args)...));
-                // Join.
-                for (auto& future : futures)
-                    future.get();
-            }
+    // Fork.
+    for (int id = 0; id < num_threads; ++id)
+      futures.emplace_back(hpx::async(f, id, num_threads, args...));
+    // Join.
+    for (auto& future : futures)
+      future.get();
+  }
 
-            // Returns the sum of the return values of f(id, num_tasks, args...) for each integer value of id
-            // in [0, num_tasks).
-            // Precondition: the return type of f can be initialized with 0.
-            // TODO: ONE PLACE
-            template <class F, class... Args>
-            auto sumReduction(int num_threads, F&& f, Args&&... args) {
-                assert(num_threads > 0);
+  // Returns the sum of the return values of f(id, num_tasks, args...) for each integer value of id
+  // in [0, num_tasks).
+  // Precondition: the return type of f can be initialized with 0.
+  // TODO: ONE PLACE
+  template <class F, class... Args>
+  auto sumReduction(int num_threads, F&& f, Args&&... args) {
+    assert(num_threads > 0);
 
-                using ReturnType = typename std::result_of<F(int, int, Args...)>::type;
+    using ReturnType = typename std::result_of<F(int, int, Args...)>::type;
 
-                std::vector<hpx::future<ReturnType>> futures;
-//                auto& pool = HPXThreadPool::get_instance();
-//                pool.enlarge(num_threads);
+    std::vector<hpx::future<ReturnType>> futures;
 
-                // Spawn num_threads tasks.
-                for (int id = 0; id < num_threads; ++id)
-                    futures.emplace_back(
-                            hpx::async(std::forward<F>(f), id, num_threads, std::forward<Args>(args)...));
-                // Sum the result of the tasks.
-                ReturnType result = 0;
-                for (auto& future : futures)
-                    result += future.get();
+    // Spawn num_threads tasks.
+    for (int id = 0; id < num_threads; ++id)
+      futures.emplace_back(hpx::async(f, id, num_threads, args...));
+    // Sum the result of the tasks.
+    ReturnType result = 0;
+    for (auto& future : futures)
+      result += future.get();
 
-                return result;
-            }
+    return result;
+  }
 
-//            friend std::ostream& operator<<(std::ostream& some_ostream, const hpxthread& this_concurrency);
+  friend std::ostream& operator<<(std::ostream& some_ostream, const hpxthread& this_concurrency);
 
-        private:
-            static constexpr char parallel_type_str_[] = "stdthread";
-        };
+private:
+  static constexpr char parallel_type_str_[] = "hpxthread";
+};
 
-    }  //  parallel
-}  //  dca
+}  // namespace parallel
+}  // namespace dca
 
 #endif  // DCA_PARALLEL_HPXDTHREAD_HPXTHREAD_HPP

--- a/include/dca/parallel/mpi_concurrency/mpi_collective_max.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_collective_max.hpp
@@ -26,7 +26,7 @@ public:
   MPICollectiveMax() = default;
 
   template <typename Scalar>
-  void max(Scalar& value) const {
+  void (max)(Scalar& value) const {
     Scalar result;
 
     MPI_Allreduce(&value, &result, 1, MPITypeMap<Scalar>::value(),

--- a/include/dca/parallel/mpi_concurrency/mpi_collective_min.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_collective_min.hpp
@@ -26,7 +26,7 @@ public:
   MPICollectiveMin() = default;
 
   template <typename Scalar>
-  void min(Scalar& value) const {
+  void (min)(Scalar& value) const {
     Scalar result;
 
     MPI_Allreduce(&value, &result, 1, MPITypeMap<Scalar>::value(),

--- a/include/dca/parallel/mpi_concurrency/mpi_collective_sum.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_collective_sum.hpp
@@ -561,11 +561,11 @@ template <typename T>
 void MPICollectiveSum::sum(const T* in, T* out, std::size_t n, int root_id) const {
   // On summit large messages hangs if sizeof(floating point type) * message_size > 2^31-1.
   constexpr std::size_t max_size = dca::util::IsComplex<T>::value
-                                       ? 2 * (std::numeric_limits<int>::max() / sizeof(T))
-                                       : std::numeric_limits<int>::max() / sizeof(T);
+                                       ? 2 * ((std::numeric_limits<int>::max)() / sizeof(T))
+                                       : (std::numeric_limits<int>::max)() / sizeof(T);
 
   for (std::size_t start = 0; start < n; start += max_size) {
-    const int msg_size = std::min(n - start, max_size);
+    const int msg_size = (std::min)(n - start, max_size);
     if (root_id == -1) {
       MPI_Allreduce(in + start, out + start, msg_size, MPITypeMap<T>::value(), MPI_SUM,
                     MPIProcessorGrouping::get());

--- a/include/dca/parallel/mpi_concurrency/mpi_packing.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_packing.hpp
@@ -200,8 +200,10 @@ void MPIPacking::pack(char* buffer, int size, int& off_set,
   int vectorSize(str.size());
   pack(buffer, size, off_set, vectorSize);
 
-  MPI_Pack(&str[0], vectorSize, MPITypeMap<scalar_type>::value(), buffer, size, &off_set,
-           MPIProcessorGrouping::get());
+  if (!str.empty()) {
+    MPI_Pack(&str[0], vectorSize, MPITypeMap<scalar_type>::value(), buffer, size, &off_set,
+             MPIProcessorGrouping::get());
+  }
 }
 
 template <typename scalar_type>
@@ -210,8 +212,10 @@ void MPIPacking::pack(char* buffer, int size, int& off_set, const std::vector<sc
   int vectorSize(v.size());
   pack(buffer, size, off_set, vectorSize);
 
-  MPI_Pack(&v[0], vectorSize, MPITypeMap<scalar_type>::value(), buffer, size, &off_set,
-           MPIProcessorGrouping::get());
+  if (!v.empty()) {
+    MPI_Pack(&v[0], vectorSize, MPITypeMap<scalar_type>::value(), buffer, size, &off_set,
+             MPIProcessorGrouping::get());
+  }
 }
 
 template <typename scalar_type>
@@ -299,11 +303,12 @@ void MPIPacking::unpack(char* buffer, int size, int& off_set,
   int vectorSize(0);
   unpack(buffer, size, off_set, vectorSize);
 
-  str.resize(vectorSize);
-
   // UnPack the vector
-  MPI_Unpack(buffer, size, &off_set, static_cast<scalar_type*>(&str[0]), 1 * vectorSize,
-             MPITypeMap<scalar_type>::value(), MPIProcessorGrouping::get());
+  if (vectorSize != 0) {
+    str.resize(vectorSize);
+    MPI_Unpack(buffer, size, &off_set, static_cast<scalar_type*>(&str[0]), 1 * vectorSize,
+               MPITypeMap<scalar_type>::value(), MPIProcessorGrouping::get());
+  }
 }
 
 template <typename scalar_type>
@@ -312,11 +317,13 @@ void MPIPacking::unpack(char* buffer, int size, int& off_set, std::vector<scalar
   int vectorSize(0);
   unpack(buffer, size, off_set, vectorSize);
 
-  v.resize(vectorSize);
+  if (vectorSize != 0) {
+    v.resize(vectorSize);
 
-  // UnPack the vector
-  MPI_Unpack(buffer, size, &off_set, static_cast<scalar_type*>(&v[0]), 1 * vectorSize,
-             MPITypeMap<scalar_type>::value(), MPIProcessorGrouping::get());
+    // UnPack the vector
+    MPI_Unpack(buffer, size, &off_set, static_cast<scalar_type*>(&v[0]), 1 * vectorSize,
+               MPITypeMap<scalar_type>::value(), MPIProcessorGrouping::get());
+  }
 }
 
 template <typename scalar_type>

--- a/include/dca/parallel/mpi_concurrency/mpi_type_map.hpp
+++ b/include/dca/parallel/mpi_concurrency/mpi_type_map.hpp
@@ -103,6 +103,15 @@ struct MPITypeMap<std::complex<double>> {
   }
 };
 
+#if defined(_MSC_VER)
+template <>
+struct MPITypeMap<unsigned long int> {
+  static MPI_Datatype value() {
+    return MPI_DOUBLE_COMPLEX;
+  }
+};
+#endif
+
 }  // namespace parallel
 }  // namespace dca
 

--- a/include/dca/parallel/stdthread/stdthread.hpp
+++ b/include/dca/parallel/stdthread/stdthread.hpp
@@ -38,8 +38,7 @@ public:
 
     // Fork.
     for (int id = 0; id < num_threads; ++id)
-      futures.emplace_back(
-          pool.enqueue(std::forward<F>(f), id, num_threads, std::forward<Args>(args)...));
+      futures.emplace_back(pool.enqueue(f, id, num_threads, args...));
     // Join.
     for (auto& future : futures)
       future.get();
@@ -60,8 +59,7 @@ public:
 
     // Spawn num_threads tasks.
     for (int id = 0; id < num_threads; ++id)
-      futures.emplace_back(
-          pool.enqueue(std::forward<F>(f), id, num_threads, std::forward<Args>(args)...));
+      futures.emplace_back(pool.enqueue(f, id, num_threads, args...));
     // Sum the result of the tasks.
     ReturnType result = 0;
     for (auto& future : futures)

--- a/include/dca/phys/dca_step/cluster_solver/ctaux/structs/vertex_singleton.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/structs/vertex_singleton.hpp
@@ -36,7 +36,7 @@ public:
 
   vertex_singleton(const this_type& other_vertex_couple);
 
-  this_type& operator=(this_type& other_vertex_couple);
+//   this_type& operator=(this_type& other_vertex_couple);
 
   this_type& operator=(const this_type& other_vertex_couple);
 

--- a/include/dca/phys/dca_step/cluster_solver/ss_ct_hyb/structures/hybridization_vertex.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ss_ct_hyb/structures/hybridization_vertex.hpp
@@ -34,11 +34,11 @@ public:
     t_end_val = t_end;
   }
 
-  this_type& operator=(this_type& other_vertex) {
-    t_start_val = other_vertex.t_start();
-    t_end_val = other_vertex.t_end();
-    return *this;
-  }
+//   this_type& operator=(this_type& other_vertex) {
+//     t_start_val = other_vertex.t_start();
+//     t_end_val = other_vertex.t_end();
+//     return *this;
+//   }
   this_type& operator=(const this_type& other_vertex) {
     t_start_val = other_vertex.t_start();
     t_end_val = other_vertex.t_end();

--- a/include/dca/phys/dca_step/symmetrization/symmetrize_single_particle_function.hpp
+++ b/include/dca/phys/dca_step/symmetrization/symmetrize_single_particle_function.hpp
@@ -37,6 +37,7 @@
 #ifndef DCA_PHYS_DCA_STEP_SYMMETRIZATION_SYMMETRIZE_SINGLE_PARTICLE_FUNCTION_HPP
 #define DCA_PHYS_DCA_STEP_SYMMETRIZATION_SYMMETRIZE_SINGLE_PARTICLE_FUNCTION_HPP
 
+#include <algorithm>
 #include <cmath>
 #include <complex>
 #include <iostream>
@@ -373,7 +374,7 @@ void symmetrize_single_particle_function::execute(func::function<scalartype, t>&
 
   double max = 0;
   for (int i = 0; i < t::dmn_size() / 2; i++) {
-    max = std::max(max, abs((f(i) + f(i + shift)) / 2.));
+    max = (std::max)(max, abs((f(i) + f(i + shift)) / 2.));
 
     scalartype tmp = (f(i) - f(i + shift)) / 2.;
 
@@ -408,7 +409,7 @@ void symmetrize_single_particle_function::executeTimeOrFreq(
 
   double max = 0;
   for (int ind = 0; ind < f.size(); ++ind) {
-    max = std::max(max, std::abs(f(ind) - f_new(ind)));
+    max = (std::max)(max, std::abs(f(ind) - f_new(ind)));
   }
 
   f = std::move(f_new);
@@ -421,7 +422,7 @@ template <typename scalartype>
 void symmetrize_single_particle_function::execute(func::function<scalartype, w>& f, bool do_diff) {
   double max = 0;
   for (int i = 0; i < w::dmn_size() / 2; i++) {
-    max = std::max(max, abs((f(i) - std::conj(f(w::dmn_size() - i - 1))) / 2.));
+    max = (std::max)(max, abs((f(i) - std::conj(f(w::dmn_size() - i - 1))) / 2.));
 
     scalartype tmp = (f(i) + std::conj(f(w::dmn_size() - i - 1))) / 2.;
 
@@ -460,7 +461,7 @@ void symmetrize_single_particle_function::executeTimeOrFreq(
 
   double max = 0;
   for (int ind = 0; ind < f.size(); ++ind) {
-    max = std::max(max, abs(f(ind) - f_new(ind)));
+    max = (std::max)(max, abs(f(ind) - f_new(ind)));
   }
 
   f = std::move(f_new);
@@ -482,7 +483,7 @@ void symmetrize_single_particle_function::execute(func::function<scalartype, w_V
                                                   bool do_diff) {
   double max = 0;
   for (int i = 0; i < w_VERTEX::dmn_size() / 2; i++) {
-    max = std::max(max, abs((f(i) - std::conj(f(w_VERTEX::dmn_size() - i - 1))) / 2.));
+    max = (std::max)(max, abs((f(i) - std::conj(f(w_VERTEX::dmn_size() - i - 1))) / 2.));
 
     scalartype tmp = (f(i) + std::conj(f(w_VERTEX::dmn_size() - i - 1))) / 2.;
 
@@ -499,7 +500,7 @@ void symmetrize_single_particle_function::execute(func::function<scalartype, w_V
                                                   bool do_diff) {
   double max = 0;
   for (int i = 0; i < w_VERTEX_EXTENDED::dmn_size() / 2; i++) {
-    max = std::max(max, abs((f(i) - std::conj(f(w_VERTEX_EXTENDED::dmn_size() - i - 1))) / 2.));
+    max = (std::max)(max, abs((f(i) - std::conj(f(w_VERTEX_EXTENDED::dmn_size() - i - 1))) / 2.));
 
     scalartype tmp = (f(i) + std::conj(f(w_VERTEX_EXTENDED::dmn_size() - i - 1))) / 2.;
 
@@ -546,7 +547,7 @@ void symmetrize_single_particle_function::executeCluster(
 
   double max = 0;
   for (int ind = 0; ind < f.size(); ++ind) {
-    max = std::max(max, std::abs(f(ind) - f_new(ind)));
+    max = (std::max)(max, std::abs(f(ind) - f_new(ind)));
 
     f(ind) = f_new(ind);
   }
@@ -599,7 +600,7 @@ void symmetrize_single_particle_function::executeCluster(
 
   double max = 0;
   for (int ind = 0; ind < f.size(); ++ind) {
-    max = std::max(max, std::abs(f(ind) - f_new(ind)));
+    max = (std::max)(max, std::abs(f(ind) - f_new(ind)));
 
     f(ind) = f_new(ind);
   }
@@ -643,7 +644,7 @@ void symmetrize_single_particle_function::executeCluster(
 
   double max = 0;
   for (int ind = 0; ind < f.size(); ++ind) {
-    max = std::max(max, abs(f(ind) - f_new(ind)));
+    max = (std::max)(max, abs(f(ind) - f_new(ind)));
 
     f(ind) = f_new(ind);
   }
@@ -693,7 +694,7 @@ void symmetrize_single_particle_function::executeCluster(
 
   double max = 0;
   for (int ind = 0; ind < f.size(); ++ind) {
-    max = std::max(max, std::abs(f(ind) - f_new(ind)));
+    max = (std::max)(max, std::abs(f(ind) - f_new(ind)));
 
     f(ind) = f_new(ind);
   }

--- a/include/dca/phys/domains/cluster/cluster_operations.hpp
+++ b/include/dca/phys/domains/cluster/cluster_operations.hpp
@@ -14,6 +14,7 @@
 #define DCA_PHYS_DOMAINS_CLUSTER_CLUSTER_OPERATIONS_HPP
 
 #include <cassert>
+#include <ciso646>
 #include <cmath>
 #include <utility>
 #include <vector>

--- a/include/dca/phys/parameters/mci_parameters.hpp
+++ b/include/dca/phys/parameters/mci_parameters.hpp
@@ -99,7 +99,7 @@ public:
 private:
   void generateRandomSeed() {
     std::random_device rd;
-    std::uniform_int_distribution<int> dist(0, std::numeric_limits<int>::max());
+    std::uniform_int_distribution<int> dist(0, (std::numeric_limits<int>::max)());
     seed_ = dist(rd);
   }
 

--- a/include/dca/profiling/events/time.hpp
+++ b/include/dca/profiling/events/time.hpp
@@ -15,8 +15,124 @@
 #include <stdexcept>
 #include <sstream>
 
+#if !defined(_MSC_VER)
 #include <sys/resource.h>
 #include <sys/time.h>
+#else
+#include <time.h>
+#include <windows.h>
+#include <psapi.h>
+
+#define DELTA_EPOCH_IN_MICROSECS  11644473600000000Ui64
+
+struct timezone
+{
+  int  tz_minuteswest; /* minutes W of Greenwich */
+  int  tz_dsttime;     /* type of dst correction */
+};
+
+inline int gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+  FILETIME ft;
+  unsigned __int64 tmpres = 0;
+  static int tzflag;
+
+  if (nullptr != tv)
+  {
+    GetSystemTimeAsFileTime(&ft);
+
+    tmpres |= ft.dwHighDateTime;
+    tmpres <<= 32;
+    tmpres |= ft.dwLowDateTime;
+
+    /*converting file time to unix epoch*/
+    tmpres -= DELTA_EPOCH_IN_MICROSECS;
+    tmpres /= 10;  /*convert into microseconds*/
+    tv->tv_sec = (long)(tmpres / 1000000UL);
+    tv->tv_usec = (long)(tmpres % 1000000UL);
+  }
+
+  if (nullptr != tz)
+  {
+    if (!tzflag)
+    {
+      _tzset();
+      tzflag++;
+    }
+    tz->tz_minuteswest = _timezone / 60;
+    tz->tz_dsttime = _daylight;
+  }
+
+  return 0;
+}
+
+#define RUSAGE_SELF 0
+#define	RUSAGE_THREAD 1
+
+struct rusage {
+  struct timeval ru_utime; /* user time used */
+  struct timeval ru_stime; /* system time used */
+  long ru_maxrss;
+  long ru_ixrss; /* XXX: 0 */
+  long ru_idrss; /* XXX: sum of rm_asrss */
+  long ru_isrss; /* XXX: 0 */
+  long ru_minflt; /* any page faults not requiring I/O */
+  long ru_majflt; /* any page faults requiring I/O */
+  long ru_nswap; /* swaps */
+  long ru_inblock; /* block input operations */
+  long ru_oublock; /* block output operations */
+  long ru_msgsnd; /* messages sent */
+  long ru_msgrcv; /* messages received */
+  long ru_nsignals; /* signals received */
+  long ru_nvcsw; /* voluntary context switches */
+  long ru_nivcsw; /* involuntary " */
+
+#define ru_last ru_nivcsw
+};
+
+inline void usage_to_timeval(FILETIME* ft, struct timeval* tv) {
+  ULARGE_INTEGER time;
+  time.LowPart = ft->dwLowDateTime;
+  time.HighPart = ft->dwHighDateTime;
+
+  tv->tv_sec = time.QuadPart / 10000000;
+  tv->tv_usec = (time.QuadPart % 10000000) / 10;
+}
+
+inline int getrusage(int who, struct rusage* usage) {
+  FILETIME creation_time, exit_time, kernel_time, user_time;
+  PROCESS_MEMORY_COUNTERS pmc;
+
+  memset(usage, 0, sizeof(struct rusage));
+
+  if (who == RUSAGE_SELF) {
+    if (!GetProcessTimes(GetCurrentProcess(), &creation_time, &exit_time, &kernel_time, &user_time)) {
+      return -1;
+    }
+
+    if (!GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc))) {
+      return -1;
+    }
+
+    usage_to_timeval(&kernel_time, &usage->ru_stime);
+    usage_to_timeval(&user_time, &usage->ru_utime);
+    usage->ru_majflt = pmc.PageFaultCount;
+    usage->ru_maxrss = pmc.PeakWorkingSetSize / 1024;
+    return 0;
+  }
+  else if (who == RUSAGE_THREAD) {
+    if (!GetThreadTimes(GetCurrentThread(), &creation_time, &exit_time, &kernel_time, &user_time)) {
+      return -1;
+    }
+    usage_to_timeval(&kernel_time, &usage->ru_stime);
+    usage_to_timeval(&user_time, &usage->ru_utime);
+    return 0;
+  }
+  else {
+    return -1;
+  }
+}
+#endif
 
 namespace dca {
 namespace profiling {

--- a/include/dca/util/print_type.hpp
+++ b/include/dca/util/print_type.hpp
@@ -11,7 +11,9 @@
 #ifndef DCA_UTIL_PRINT_TYPE_HPP
 #define DCA_UTIL_PRINT_TYPE_HPP
 
+#if !defined(_MSC_VER)
 #include <cxxabi.h>
+#endif
 #include <memory>
 #include <sstream>
 #include <string>
@@ -23,9 +25,13 @@ namespace detail {
 // dca::util::detail::
 
 inline std::string demangle(std::string const& str, int& status) {
+#if !defined(_MSC_VER)
   std::unique_ptr<char, void (*)(void*)> dmgl(abi::__cxa_demangle(str.c_str(), 0, 0, &status),
                                               std::free);
   return (status == 0) ? dmgl.get() : str;
+#else
+  return str;
+#endif
 }
 
 }  // detail

--- a/libs/simplex_gm_rule/CMakeLists.txt
+++ b/libs/simplex_gm_rule/CMakeLists.txt
@@ -3,9 +3,11 @@
 add_library(simplex_gm_rule STATIC simplex_gm_rule.cpp)
 
 # Silence compiler warnings.
-target_compile_options(simplex_gm_rule PRIVATE "-Wno-unused-parameter")
-if (CMAKE_COMPILER_IS_GNUCXX)
-  target_compile_options(simplex_gm_rule PRIVATE "-Wno-unused-but-set-variable")
+if(NOT MSVC)
+  target_compile_options(simplex_gm_rule PRIVATE "-Wno-unused-parameter")
+  if (CMAKE_COMPILER_IS_GNUCXX)
+    target_compile_options(simplex_gm_rule PRIVATE "-Wno-unused-but-set-variable")
+  endif()
 endif()
 
 set(SIMPLEX_GM_RULE_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "")

--- a/src/io/hdf5/hdf5_reader.cpp
+++ b/src/io/hdf5/hdf5_reader.cpp
@@ -11,6 +11,7 @@
 
 #include "dca/io/hdf5/hdf5_reader.hpp"
 
+#include <ciso646>
 #include <fstream>
 #include <stdexcept>
 

--- a/src/io/hdf5/hdf5_writer.cpp
+++ b/src/io/hdf5/hdf5_writer.cpp
@@ -11,6 +11,7 @@
 
 #include "dca/io/hdf5/hdf5_writer.hpp"
 
+#include <ciso646>
 #include <fstream>
 #include <stdexcept>
 

--- a/src/io/json/json_parser/json_character_mapper.cpp
+++ b/src/io/json/json_parser/json_character_mapper.cpp
@@ -70,7 +70,7 @@ bool JSON_character_mapper::is_white_space(JSON_character_class_type& nextClass)
   }
 }
 
-wchar_t JSON_character_mapper::get_escaped_character(std::wistream& inputStream) {
+wchar_t JSON_character_mapper::get_escaped_character(json_istream& inputStream) {
   wchar_t secondChar = inputStream.get();
 
   switch (secondChar) {

--- a/src/io/json/json_reader.cpp
+++ b/src/io/json/json_reader.cpp
@@ -45,7 +45,7 @@ std::string JSONReader::get_path() {
 void JSONReader::parse(std::string& file_name_ref) {
   std::string file_name = file_name_ref;
 
-  std::wifstream file(file_name.c_str());
+  json_ifstream file(file_name.c_str());
 
   if (!file or !file.good() or file.bad()) {
     std::cout << "\n\n\tcannot open file : " << file_name << "\n";

--- a/src/parallel/hpx/CMakeLists.txt
+++ b/src/parallel/hpx/CMakeLists.txt
@@ -11,7 +11,7 @@ configure_file("${PROJECT_SOURCE_DIR}/include/dca/config/hpx_defines.hpp.in"
 #add_library(parallel_hpxthread STATIC hpxthread.cpp)
 find_package(HPX REQUIRED NO_CMAKE_PACKAGE_REGISTRY)
 add_library(parallel_hpxthread STATIC hpxthread.cpp)
-#        hpx_thread_pool/hpx_thread_pool.cpp hpx_thread_pool/affinity.cpp)
+
 hpx_setup_target(parallel_hpxthread
         COMPONENT_DEPENDENCIES iostreams)
 #target_include_directories(parallel_hpxthread PUBLIC ${HPX_INCLUDE_DIRS} ${DCA_INCLUDE_DIRS})

--- a/src/parallel/hpx/hpxthread.cpp
+++ b/src/parallel/hpx/hpxthread.cpp
@@ -9,19 +9,22 @@
 //
 // This file implements hpxthread.hpp.
 
+#include <iostream>
+
 #include "dca/parallel/hpx/hpxthread.hpp"
+#include "hpx/runtime/get_worker_thread_num.hpp"
 
 namespace dca {
-    namespace parallel {
+namespace parallel {
 
-        constexpr char hpxthread::parallel_type_str_[];
+constexpr char hpxthread::parallel_type_str_[];
 
-//        hpx::ostream& operator<<(hpx::ostream& o, const hpxthread& c) {
-//            o << '\n'
-//              << "threading type:" << c.parallel_type_str_ << '\n'
-//              << "number of std::threads:" << HPXThreadPool::get_instance().size();
-//            return o;
-//        }
+std::ostream& operator<<(std::ostream& o, const hpxthread& c) {
+  o << '\n'
+    << "threading type:" << c.parallel_type_str_ << '\n'
+    << "number of HPX worker threads:" << hpx::get_num_worker_threads();
+  return o;
+}
 
-    }  // parallel
-}  // dca
+}  // namespace parallel
+}  // namespace dca

--- a/src/parallel/mpi_concurrency/mpi_gang.cpp
+++ b/src/parallel/mpi_concurrency/mpi_gang.cpp
@@ -11,6 +11,7 @@
 
 #include "dca/parallel/mpi_concurrency/mpi_gang.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 #include "dca/util/integer_division.hpp"
@@ -24,7 +25,7 @@ MPIGang::MPIGang(const dca::parallel::MPIProcessorGrouping& group, int min_size)
 
 
   const int n_gangs = group.get_size() / min_size;
-  const int gang_id = std::min(group.get_id() / min_size, n_gangs - 1);
+  const int gang_id = (std::min)(group.get_id() / min_size, n_gangs - 1);
 
   MPI_Comm_split(group.get(), gang_id, 0, &communicator_);
   MPI_Comm_size(communicator_, &size_);

--- a/src/parallel/mpi_concurrency/mpi_processor_grouping.cpp
+++ b/src/parallel/mpi_concurrency/mpi_processor_grouping.cpp
@@ -12,7 +12,9 @@
 #include "dca/parallel/mpi_concurrency/mpi_processor_grouping.hpp"
 
 #include <iostream>
+#if !defined(_MSC_VER)
 #include <unistd.h>
+#endif
 
 #include "dca/parallel/mpi_concurrency/kernel_test.hpp"
 

--- a/src/parallel/stdthread/CMakeLists.txt
+++ b/src/parallel/stdthread/CMakeLists.txt
@@ -1,3 +1,10 @@
 # parallel stdthread
 add_library(parallel_stdthread STATIC stdthread.cpp
                                       thread_pool/thread_pool.cpp thread_pool/affinity.cpp)
+
+if(MSVC)
+  # Find HWLOC
+  include(dca_hwloc)
+  target_include_directories(parallel_stdthread PUBLIC ${HWLOC_INCLUDE_DIR})
+  target_link_libraries(parallel_stdthread PUBLIC ${HWLOC_LIBRARY})
+endif()

--- a/src/parallel/stdthread/thread_pool/affinity.cpp
+++ b/src/parallel/stdthread/thread_pool/affinity.cpp
@@ -19,14 +19,130 @@
 #define _GNU_SOURCE
 #endif
 
+#if !defined(_MSC_VER)
 #include <sched.h>
+#else
+#include <hwloc.h>
+#endif
+
 #include <stdexcept>
+
+#if defined(_MSC_VER)
+struct topology {
+  topology() : topo(nullptr) {
+    int err = hwloc_topology_init(&topo);
+    if (err != 0) {
+      throw(std::runtime_error("Unable to get thread topology information."));
+    }
+    err = hwloc_topology_ignore_type(topo, HWLOC_OBJ_PACKAGE);
+    if (err != 0) {
+      throw(std::runtime_error("hwloc_topology_ignore_type(HWLOC_OBJ_PACKAGE) failed."));
+    }
+    err = hwloc_topology_ignore_type(topo, HWLOC_OBJ_CACHE);
+    if (err != 0) {
+      throw(std::runtime_error("hwloc_topology_ignore_type(HWLOC_OBJ_CACHE) failed."));
+    }
+    err = hwloc_topology_ignore_type(topo, HWLOC_OBJ_GROUP);
+    if (err != 0) {
+      throw(std::runtime_error("hwloc_topology_ignore_type(HWLOC_OBJ_GROUP) failed."));
+    }
+    err = hwloc_topology_load(topo);
+    if (err != 0) {
+      throw(std::runtime_error("Unable to fill thread topology information."));
+    }
+  }
+  ~topology() {
+    if(topo) {
+      hwloc_topology_destroy(topo);
+    }
+  }
+
+  int get_number_of_cores() const {
+    int nobjs = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE);
+    // If num_cores is smaller 0, we have an error
+    if (0 > nobjs) {
+      throw(std::runtime_error("hwloc_get_nbobjs_by_type(HWLOC_OBJ_CORE) failed."));
+    }
+    else if (0 == nobjs) {
+      // some platforms report zero cores but might still report the number of PUs
+      nobjs = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
+      if (0 > nobjs) {
+        throw(std::runtime_error("hwloc_get_nbobjs_by_type(HWLOC_OBJ_PU) failed."));
+      }
+    }
+
+    // the number of reported cores/pus should never be zero either to
+    // avoid division by zero, we should always have at least one core
+    if (0 == nobjs) {
+      throw(std::runtime_error("hwloc_get_nbobjs_by_type reports zero cores/pus."));
+    }
+    return nobjs;
+  }
+
+  int get_index(hwloc_obj_t obj) const {
+    // on Windows logical_index is always -1
+    if (obj->logical_index == ~0x0u)
+      return obj->os_index;
+    return obj->logical_index;
+  }
+
+  int get_cpubind_mask() const {
+    hwloc_cpuset_t cpuset = hwloc_bitmap_alloc();
+
+    int mask = 0;
+
+    if (hwloc_get_cpubind(topo, cpuset, HWLOC_CPUBIND_PROCESS)) {
+      hwloc_bitmap_free(cpuset);
+      throw(std::runtime_error("hwloc_get_cpubind failed."));
+    }
+
+    int depth = hwloc_get_type_or_below_depth(topo, HWLOC_OBJ_CORE);
+    int cores = get_number_of_cores();
+    for (unsigned int i = 0; i != cores; ++i)
+    {
+      hwloc_obj_t core_obj = hwloc_get_obj_by_depth(topo, depth, i);
+      unsigned idx = unsigned(get_index(core_obj));
+      if (hwloc_bitmap_isset(cpuset, idx) != 0) {
+        mask |= 0x1 << idx;
+      }
+    }
+    hwloc_bitmap_free(cpuset);
+    return mask;
+  }
+
+  void set_cpubind_mask(int mask) const {
+    hwloc_cpuset_t cpuset = hwloc_bitmap_alloc();
+
+    int depth = hwloc_get_type_or_below_depth(topo, HWLOC_OBJ_CORE);
+
+    int cores = get_number_of_cores();
+    for (int i = 0; i != cores; ++i) {
+      if (mask & (0x1 << i)) {
+        hwloc_obj_t core_obj = hwloc_get_obj_by_depth(topo, depth, unsigned(i));
+        hwloc_bitmap_set(cpuset, unsigned(get_index(core_obj)));
+      }
+    }
+
+    if (hwloc_set_cpubind(topo, cpuset, HWLOC_CPUBIND_STRICT | HWLOC_CPUBIND_PROCESS)) {
+      // Strict binding not supported or failed, try weak binding.
+      if (hwloc_set_cpubind(topo, cpuset, HWLOC_CPUBIND_PROCESS)) {
+        hwloc_bitmap_free(cpuset);
+        throw(std::runtime_error("hwloc_set_cpubind failed."));
+      }
+    }
+    hwloc_bitmap_free(cpuset);
+  }
+
+  hwloc_topology_t topo;
+};
+#endif
 
 namespace dca {
 namespace parallel {
 // dca::parallel::
 
 std::vector<int> get_affinity() {
+#if !defined(_MSC_VER)
   cpu_set_t cpu_set_mask;
 
   auto status = sched_getaffinity(0, sizeof(cpu_set_t), &cpu_set_mask);
@@ -51,9 +167,26 @@ std::vector<int> get_affinity() {
   }
 
   return cores;
+#else
+  topology topo;
+
+  int num_cores = topo.get_number_of_cores();
+  std::vector<int> cores;
+  cores.reserve(num_cores);
+
+  int cpu_mask = topo.get_cpubind_mask();
+  for (int i = 0; i != num_cores; ++i) {
+    if (cpu_mask & (0x1 << i)) {
+      cores.push_back(i);
+    }
+  }
+
+  return cores;
+#endif
 }
 
 void set_affinity(const std::vector<int>& cores) {
+#if !defined(_MSC_VER)
   cpu_set_t cpu_set_mask;
   CPU_ZERO(&cpu_set_mask);
 
@@ -62,12 +195,25 @@ void set_affinity(const std::vector<int>& cores) {
   }
 
   sched_setaffinity(0, sizeof(cpu_set_t), &cpu_set_mask);
+#else
+  topology topo;
+  int cpu_mask = 0;
+  for (int core : cores) {
+    cpu_mask |= 0x1 << core;
+  }
+  topo.set_cpubind_mask(cpu_mask);
+#endif
 }
 
 int get_core_count() {
+#if !defined(_MSC_VER)
   cpu_set_t cpu_set_mask;
   sched_getaffinity(0, sizeof(cpu_set_t), &cpu_set_mask);
   return CPU_COUNT(&cpu_set_mask);
+#else
+  topology topo;
+  return topo.get_number_of_cores();
+#endif
 }
 
 }  // namespace parallel

--- a/src/phys/dca_step/cluster_mapping/coarsegraining/tetrahedron_routines_harmonic_function.cpp
+++ b/src/phys/dca_step/cluster_mapping/coarsegraining/tetrahedron_routines_harmonic_function.cpp
@@ -13,6 +13,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <ciso646>
 
 #include "dca/math/util/vector_operations.hpp"
 

--- a/src/phys/dca_step/cluster_solver/ctaux/structs/vertex_singleton.cpp
+++ b/src/phys/dca_step/cluster_solver/ctaux/structs/vertex_singleton.cpp
@@ -54,22 +54,22 @@ vertex_singleton::vertex_singleton(const vertex_singleton& other_vertex_couple)
       HS_field(other_vertex_couple.get_HS_field()),
       configuration_index(other_vertex_couple.get_configuration_index()) {}
 
-vertex_singleton& vertex_singleton::operator=(vertex_singleton& other_vertex_couple) {
-  band = other_vertex_couple.get_band();
-  e_spin = other_vertex_couple.get_e_spin();
-  spin_orbital = other_vertex_couple.get_spin_orbital();
-
-  paired_spin_orbital = other_vertex_couple.get_paired_spin_orbital();
-  r_site = other_vertex_couple.get_r_site();
-  delta_r = other_vertex_couple.get_delta_r();
-  tau = other_vertex_couple.get_tau();
-
-  HS_spin = other_vertex_couple.get_HS_spin();
-  HS_field = other_vertex_couple.get_HS_field();
-  configuration_index = other_vertex_couple.get_configuration_index();
-
-  return *this;
-}
+// vertex_singleton& vertex_singleton::operator=(vertex_singleton& other_vertex_couple) {
+//   band = other_vertex_couple.get_band();
+//   e_spin = other_vertex_couple.get_e_spin();
+//   spin_orbital = other_vertex_couple.get_spin_orbital();
+//
+//   paired_spin_orbital = other_vertex_couple.get_paired_spin_orbital();
+//   r_site = other_vertex_couple.get_r_site();
+//   delta_r = other_vertex_couple.get_delta_r();
+//   tau = other_vertex_couple.get_tau();
+//
+//   HS_spin = other_vertex_couple.get_HS_spin();
+//   HS_field = other_vertex_couple.get_HS_field();
+//   configuration_index = other_vertex_couple.get_configuration_index();
+//
+//   return *this;
+// }
 
 vertex_singleton& vertex_singleton::operator=(const vertex_singleton& other_vertex_couple) {
   band = other_vertex_couple.get_band();

--- a/src/phys/dca_step/cluster_solver/ctaux/walker/ct_aux_walker_tools.cpp
+++ b/src/phys/dca_step/cluster_solver/ctaux/walker/ct_aux_walker_tools.cpp
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <stdexcept>
 #include <iostream>
+#include <ciso646>
 
 namespace dca {
 namespace phys {

--- a/src/phys/domains/time_and_frequency/frequency_exchange_domain.cpp
+++ b/src/phys/domains/time_and_frequency/frequency_exchange_domain.cpp
@@ -10,6 +10,7 @@
 // This files implements the methods of frequency_exchange_domain.hpp.
 
 #include <stdexcept>
+#include <algorithm>
 
 #include "dca/phys/domains/time_and_frequency/frequency_exchange_domain.hpp"
 
@@ -42,7 +43,7 @@ void FrequencyExchangeDomain::initialize(const bool compute_all_transfers,
   // Compute the extension size.
   extension_size_ = 0;
   for (auto el : elements_)
-    extension_size_ = std::max(extension_size_, std::abs(el));
+    extension_size_ = (std::max)(extension_size_, std::abs(el));
 
   initialized_ = true;
 }

--- a/test/integration/coarsegraining/CMakeLists.txt
+++ b/test/integration/coarsegraining/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 dca_add_gtest(coarsegraining_test
         EXTENSIVE
-        GTEST_MAIN
+#        GTEST_MAIN
         HPX
         MPI MPI_NUMPROC 1
         INCLUDE_DIRS ${DCA_INCLUDE_DIRS}

--- a/test/integration/coarsegraining/coarsegraining_test.cpp
+++ b/test/integration/coarsegraining/coarsegraining_test.cpp
@@ -188,3 +188,10 @@ void computeMockSigma(SigmaType& Sigma) {
           Sigma(b, s, b, s, k, w) = sigma_val;
   }
 }
+
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/integration/coarsegraining/coarsegraining_test.cpp
+++ b/test/integration/coarsegraining/coarsegraining_test.cpp
@@ -53,7 +53,7 @@ constexpr bool write_G_r_w = false;
 
 const std::string input_dir = DCA_SOURCE_DIR "/test/integration/coarsegraining/";
 
-using Concurrency = dca::parallel::MPIConcurrency;
+using MPIConcurrency = dca::parallel::MPIConcurrency;
 using Model1 = dca::phys::models::TightBindingModel<
     dca::phys::models::singleband_chain<dca::phys::domains::no_symmetry<2>>>;
 using Model2 = dca::phys::models::TightBindingModel<
@@ -61,11 +61,11 @@ using Model2 = dca::phys::models::TightBindingModel<
 using Threading = dca::parallel::hpxthread;
 
 #ifdef UPDATE_BASELINE
-using Parameters = dca::phys::params::Parameters<Concurrency, Threading, dca::profiling::NullProfiler,
+using Parameters = dca::phys::params::Parameters<MPIConcurrency, Threading, dca::profiling::NullProfiler,
                                                  Model1, void, dca::phys::solver::CT_AUX>;
 const std::string input = input_dir + "input_singleband.json";
 #else
-using Parameters = dca::phys::params::Parameters<Concurrency, Threading, dca::profiling::NullProfiler,
+using Parameters = dca::phys::params::Parameters<MPIConcurrency, Threading, dca::profiling::NullProfiler,
                                                  Model2, void, dca::phys::solver::CT_AUX>;
 const std::string input = input_dir + "input_bilayer.json";
 #endif  // UPDATE_BASELINE
@@ -80,7 +80,7 @@ template <class SigmaType>
 void computeMockSigma(SigmaType& Sigma);
 
 void performTest(const bool test_dca_plus) {
-  static Concurrency concurrency(0, nullptr);
+  static MPIConcurrency concurrency(0, nullptr);
 //HPX_ASSERT(hpx::threads::get_self_ptr() != nullptr);
   Parameters parameters(dca::util::GitVersion::string(), concurrency);
   parameters.read_input_and_broadcast<dca::io::JSONReader>(input);

--- a/test/unit/function/CMakeLists.txt
+++ b/test/unit/function/CMakeLists.txt
@@ -7,7 +7,7 @@ dca_add_gtest(function_library_test
   GTEST_MAIN
   LIBS function)
 
-if (function_library_test)
+if (function_library_test AND NOT MSVC)
   # We want to test self-assignment and self-move.
   target_compile_options(function_library_test PRIVATE -Wno-self-assign-overloaded -Wno-self-move)
 endif()


### PR DESCRIPTION
This fixes a list of MSVC compiler incompatibilities. This also fixes several issues with the original code:

- undefined behavior while packing zero-sized vectors
- avoid using moved-from objects in executors
- removing unneeded operator=