### PR TITLE
Clean up G4 indices computation.

### DIFF
--- a/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/ctaux/ctaux_cluster_solver.hpp
@@ -454,18 +454,16 @@ void CtauxClusterSolver<device_t, Parameters, Data>::collect_measurements() {
         auto& G4 = data_.get_G4()[channel];
         // function operator = will reset this G4 size to other G4 size if they are not equal
         G4 = accumulator_.get_sign_times_G4()[channel];
-        if(parameters_.distributed_g4_enabled())
-        {
+        if (parameters_.distributed_g4_enabled()) {
           // do nothing, no accumulation should be performed as G4 size cannot fit into one GPU
           // reserve this function for testing purpose only
           // concurrency_.gatherv(G4, concurrency_.first());
         }
-        else
-        {
-            if (compute_jack_knife_)
-              concurrency_.leaveOneOutSum(G4);
-            else
-              concurrency_.localSum(G4, concurrency_.first());
+        else {
+          if (compute_jack_knife_)
+            concurrency_.leaveOneOutSum(G4);
+          else
+            concurrency_.localSum(G4, concurrency_.first());
         }
       }
     }

--- a/include/dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/kernels_interface.hpp
+++ b/include/dca/phys/dca_step/cluster_solver/shared_tools/accumulation/tp/kernels_interface.hpp
@@ -32,12 +32,11 @@ template <typename Real>
 void computeGMultiband(std::complex<Real>* G, int ldg, const std::complex<Real>* G0, int ldg0,
                        int nb, int nk, int nw_pos, Real beta, cudaStream_t stream);
 
+// Updates G4 in the range [start, end)
 template <typename Real, FourPointType type>
-float updateG4(std::complex<Real>* G4, const std::complex<Real>* G_up, const int lggu,
-              const std::complex<Real>* G_down, const int ldgd, const int nb, const int nk,
-              const int nw_pos, const int nw_exchange, const int nk_exchange, const int sign,
-              bool atomic, cudaStream_t stream, const int my_rank, const int mpi_size,
-              const uint64_t total_G4_size, const bool distributed_g4_enabled);
+float updateG4(std::complex<Real>* G4, const std::complex<Real>* G_up, const int ldgu,
+               const std::complex<Real>* G_down, const int ldgd, const int sign, bool atomic,
+               cudaStream_t stream, std::size_t start, std::size_t end);
 
 }  // namespace details
 }  // namespace accumulator

--- a/test/unit/linalg/gpu_test_util.hpp
+++ b/test/unit/linalg/gpu_test_util.hpp
@@ -25,7 +25,7 @@ cudaMemoryType PointerType(const ScalarType* ptr) {
   if (ret == cudaErrorInvalidValue)
     return cudaMemoryTypeHost;
   checkRC(ret);
-  return attributes.memoryType;
+  return attributes.type;
 }
 
 template <typename ScalarType>


### PR DESCRIPTION
I cleaned up a bit my code for computing g4 indices, and implemented what I was talking about passing the start and the end of the local storage. This should lead to a lot less if cases with the distributed and non distributed cases.
Before merging into master, this still need testing and the range selection and gathering mechanism needs to be consistent. 